### PR TITLE
Added return value to IACSuccessBlock and IACFailureBlock

### DIFF
--- a/InterAppCommunication/IACDelegate.h
+++ b/InterAppCommunication/IACDelegate.h
@@ -10,8 +10,8 @@
 
 
 // Block templates
-typedef void(^IACSuccessBlock)(NSDictionary* returnParams,BOOL cancelled);
-typedef void(^IACFailureBlock)(NSError* error);
+typedef BOOL(^IACSuccessBlock)(NSDictionary* returnParams,BOOL cancelled);
+typedef BOOL(^IACFailureBlock)(NSError* error);
 
 
 @protocol IACDelegate <NSObject>

--- a/InterAppCommunication/IACManager.m
+++ b/InterAppCommunication/IACManager.m
@@ -136,10 +136,16 @@ typedef NS_ENUM(NSUInteger, IACResponseType) {
             IACSuccessBlock success = ^(NSDictionary *returnParams, BOOL cancelled) {
                 if (cancelled) {
                     if (parameters[kXCUCancel]) {
-                        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:parameters[kXCUCancel]]];
+                        return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:parameters[kXCUCancel]]];
+                    }
+                    else {
+                        return NO;
                     }
                 } else if (parameters[kXCUSuccess]) {
-                    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[parameters[kXCUSuccess] stringByAppendingURLParams:returnParams]]];
+                    return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[parameters[kXCUSuccess] stringByAppendingURLParams:returnParams]]];
+                }
+                else {
+                    return NO;
                 }
             };
             
@@ -149,7 +155,10 @@ typedef NS_ENUM(NSUInteger, IACResponseType) {
                                                    kXCUErrorMessage: [error localizedDescription],
                                                    kIACErrorDomain: [error domain]
                                                    };
-                    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[parameters[kXCUError] stringByAppendingURLParams:errorParams]]];
+                    return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[parameters[kXCUError] stringByAppendingURLParams:errorParams]]];
+                }
+                else {
+                    return NO;
                 }
             };
 


### PR DESCRIPTION
In this way, if the client application did not send a success or a failure parameter (block), the application can know and act appropriately. For example displaying the error itself since the client app did not send a failure parameter (block).
